### PR TITLE
Add new `git rebase-with-intermediates` command

### DIFF
--- a/src/bin/git-rebase-with-intermediates.rs
+++ b/src/bin/git-rebase-with-intermediates.rs
@@ -1,0 +1,21 @@
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+#[structopt(
+    about = "Perform a rebase, and pull all the branches that were pointing at commits being rebased",
+    max_term_width = 100,
+    setting = structopt::clap::AppSettings::UnifiedHelpMessage,
+    setting = structopt::clap::AppSettings::ColoredHelp,
+)]
+struct Args {
+    /// The target ref
+    onto: String,
+}
+
+fn main() {
+    let args = Args::from_args();
+    if let Err(e) = git_fixup::rebase_onto(&args.onto) {
+        eprintln!("{:#}", e);
+        std::process::exit(1);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,336 @@
+use std::collections::HashMap;
+use std::process::Command;
+
+use anyhow::{anyhow, bail};
+use console::style;
+use dialoguer::{Confirm, Select};
+use git2::{Branch, Commit, Diff, Object, ObjectType, Oid, Rebase, Repository};
+
+#[derive(Eq, PartialEq, Debug)]
+enum Changes {
+    Staged,
+    Unstaged,
+}
+
+pub fn instafix(
+    _squash: bool,
+    max_commits: usize,
+    message_pattern: Option<String>,
+    upstream_branch_name: Option<&str>,
+) -> Result<(), anyhow::Error> {
+    let repo = Repository::open(".")?;
+    let diff = create_diff(&repo)?;
+    let head = repo
+        .head()
+        .map_err(|e| anyhow!("HEAD is not pointing at a valid branch: {}", e))?;
+    let head_branch = Branch::wrap(head);
+    println!("head_branch: {:?}", head_branch.name().unwrap().unwrap());
+    let upstream = get_upstream(&repo, &head_branch, upstream_branch_name)?;
+    let commit_to_amend = select_commit_to_amend(&repo, upstream, max_commits, &message_pattern)?;
+    do_fixup_commit(&repo, &head_branch, &commit_to_amend, false)?;
+    println!("selected: {}", disp(&commit_to_amend));
+    let current_branch = Branch::wrap(repo.head()?);
+    do_rebase(&repo, &current_branch, &commit_to_amend, &diff)?;
+
+    Ok(())
+}
+
+fn do_rebase(
+    repo: &Repository,
+    branch: &Branch,
+    commit_to_amend: &Commit,
+    diff: &Diff,
+) -> Result<(), anyhow::Error> {
+    let first_parent = repo.find_annotated_commit(commit_parent(commit_to_amend)?.id())?;
+    let branch_commit = repo.reference_to_annotated_commit(branch.get())?;
+    let fixup_commit = branch.get().peel_to_commit()?;
+    let fixup_message = fixup_commit.message();
+
+    let rebase = &mut repo
+        .rebase(Some(&branch_commit), Some(&first_parent), None, None)
+        .map_err(|e| anyhow!("Error starting rebase: {}", e))?;
+    match do_rebase_inner(repo, rebase, diff, fixup_message) {
+        Ok(_) => {
+            rebase.finish(None)?;
+            Ok(())
+        }
+        Err(e) => {
+            eprintln!("Aborting rebase, please apply it manualy via");
+            eprintln!(
+                "    git rebase --interactive --autosquash {}~",
+                first_parent.id()
+            );
+            rebase.abort()?;
+            Err(e)
+        }
+    }
+}
+
+fn do_rebase_inner(
+    repo: &Repository,
+    rebase: &mut Rebase,
+    diff: &Diff,
+    fixup_message: Option<&str>,
+) -> Result<(), anyhow::Error> {
+    let sig = repo.signature()?;
+
+    let mut branches: HashMap<Oid, Branch> = HashMap::new();
+    for (branch, _type) in repo.branches(Some(git2::BranchType::Local))?.flatten() {
+        let oid = branch.get().peel_to_commit()?.id();
+        // TODO: handle multiple branches pointing to the same commit
+        branches.insert(oid, branch);
+    }
+
+    match rebase.next() {
+        Some(ref res) => {
+            let op = res.as_ref().map_err(|e| anyhow!("No commit: {}", e))?;
+            let target_commit = repo.find_commit(op.id())?;
+            repo.apply(diff, git2::ApplyLocation::Both, None)?;
+            let mut idx = repo.index()?;
+            let oid = idx.write_tree()?;
+            let tree = repo.find_tree(oid)?;
+
+            // TODO: Support squash amends
+
+            let rewrit_id = target_commit.amend(None, None, None, None, None, Some(&tree))?;
+            repo.reset(
+                &repo.find_object(rewrit_id, None)?,
+                git2::ResetType::Soft,
+                None,
+            )?;
+
+            rewrit_id
+        }
+        None => bail!("Unable to start rebase: no first step in rebase"),
+    };
+
+    while let Some(ref res) = rebase.next() {
+        use git2::RebaseOperationType::*;
+
+        let op = res.as_ref().map_err(|e| anyhow!("Err: {}", e))?;
+        match op.kind() {
+            Some(Pick) => {
+                let commit = repo.find_commit(op.id())?;
+                if commit.message() != fixup_message {
+                    let new_id = rebase.commit(None, &sig, None)?;
+                    if let Some(branch) = branches.get_mut(&commit.id()) {
+                        branch
+                            .get_mut()
+                            .set_target(new_id, "git-fixup retarget historical branch")?;
+                    }
+                }
+            }
+            Some(Fixup) | Some(Squash) | Some(Exec) | Some(Edit) | Some(Reword) => {
+                // None of this should happen, we'd need to manually create the commits
+                bail!("Unable to handle {:?} rebase operation", op.kind().unwrap())
+            }
+            None => {}
+        }
+    }
+
+    Ok(())
+}
+
+fn commit_parent<'a>(commit: &'a Commit) -> Result<Commit<'a>, anyhow::Error> {
+    match commit.parents().next() {
+        Some(c) => Ok(c),
+        None => bail!("Commit '{}' has no parents", disp(&commit)),
+    }
+}
+
+/// Display a commit as "short_hash summary"
+fn disp(commit: &Commit) -> String {
+    format!(
+        "{} {}",
+        &commit.id().to_string()[0..10],
+        commit.summary().unwrap_or("<no summary>"),
+    )
+}
+
+fn get_upstream<'a>(
+    repo: &'a Repository,
+    head_branch: &'a Branch,
+    upstream_name: Option<&str>,
+) -> Result<Option<Object<'a>>, anyhow::Error> {
+    let upstream = if let Some(upstream_name) = upstream_name {
+        let branch = repo
+            .branches(None)?
+            .filter_map(|branch| branch.ok().map(|(b, _type)| b))
+            .find(|b| {
+                b.name()
+                    .map(|n| n.expect("valid utf8 branchname") == upstream_name)
+                    .unwrap_or(false)
+            })
+            .ok_or_else(|| anyhow!("cannot find branch with name {:?}", upstream_name))?;
+        branch.into_reference().peel(ObjectType::Commit)?
+    } else {
+        if let Ok(upstream) = head_branch.upstream() {
+            upstream.into_reference().peel(ObjectType::Commit)?
+        } else {
+            return Ok(None);
+        }
+    };
+
+    let mb = repo.merge_base(
+        head_branch
+            .get()
+            .target()
+            .expect("all branches should ahve a target"),
+        upstream.id(),
+    )?;
+    let commit = repo.find_object(mb, None).unwrap();
+
+    Ok(Some(commit))
+}
+
+/// Get a diff either from the index or the diff from the index to the working tree
+fn create_diff(repo: &Repository) -> Result<Diff, anyhow::Error> {
+    let head = repo.head()?;
+    let head_tree = head.peel_to_tree()?;
+    let staged_diff = repo.diff_tree_to_index(Some(&head_tree), None, None)?;
+    let diffstat = staged_diff.stats()?;
+    let diff = if diffstat.files_changed() == 0 {
+        let diff = repo.diff_index_to_workdir(None, None)?;
+        let dirty_workdir_stats = diff.stats()?;
+        if dirty_workdir_stats.files_changed() > 0 {
+            print_diff(Changes::Unstaged)?;
+            if !Confirm::new()
+                .with_prompt("Nothing staged, stage and commit everything?")
+                .interact()?
+            {
+                bail!("");
+            }
+        } else {
+            bail!("Nothing staged and no tracked files have any changes");
+        }
+        repo.apply(&diff, git2::ApplyLocation::Index, None)?;
+        diff
+    } else {
+        println!("Staged changes:");
+        print_diff(Changes::Staged)?;
+        staged_diff
+    };
+
+    Ok(diff)
+}
+
+/// Commit the current index as a fixup or squash commit
+fn do_fixup_commit<'a>(
+    repo: &'a Repository,
+    head_branch: &'a Branch,
+    commit_to_amend: &'a Commit,
+    squash: bool,
+) -> Result<(), anyhow::Error> {
+    let msg = if squash {
+        format!("squash! {}", commit_to_amend.id())
+    } else {
+        format!("fixup! {}", commit_to_amend.id())
+    };
+
+    let sig = repo.signature()?;
+    let mut idx = repo.index()?;
+    let tree = repo.find_tree(idx.write_tree()?)?;
+    let head_commit = head_branch.get().peel_to_commit()?;
+    repo.commit(Some("HEAD"), &sig, &sig, &msg, &tree, &[&head_commit])?;
+    Ok(())
+}
+
+fn select_commit_to_amend<'a>(
+    repo: &'a Repository,
+    upstream: Option<Object<'a>>,
+    max_commits: usize,
+    message_pattern: &Option<String>,
+) -> Result<Commit<'a>, anyhow::Error> {
+    let mut walker = repo.revwalk()?;
+    walker.push_head()?;
+    let commits = if let Some(upstream) = upstream.as_ref() {
+        let upstream_oid = upstream.id();
+        walker
+            .flat_map(|r| r)
+            .take_while(|rev| *rev != upstream_oid)
+            .take(max_commits)
+            .map(|rev| repo.find_commit(rev))
+            .collect::<Result<Vec<_>, _>>()?
+    } else {
+        walker
+            .flat_map(|r| r)
+            .take(max_commits)
+            .map(|rev| repo.find_commit(rev))
+            .collect::<Result<Vec<_>, _>>()?
+    };
+    if commits.len() == 0 {
+        bail!(
+            "No commits between {} and {:?}",
+            format_ref(&repo.head()?)?,
+            upstream.map(|u| u.id()).unwrap()
+        );
+    }
+    let branches: HashMap<Oid, String> = repo
+        .branches(None)?
+        .filter_map(|b| {
+            b.ok().and_then(|(b, _type)| {
+                let name: Option<String> = b.name().ok().and_then(|n| n.map(|n| n.to_owned()));
+                let oid = b.into_reference().resolve().ok().and_then(|r| r.target());
+                name.and_then(|name| oid.map(|oid| (oid, name)))
+            })
+        })
+        .collect();
+    if let Some(message_pattern) = message_pattern.as_ref() {
+        commits
+            .into_iter()
+            .find(|commit| {
+                commit
+                    .summary()
+                    .map(|s| s.contains(message_pattern))
+                    .unwrap_or(false)
+            })
+            .ok_or_else(|| anyhow::anyhow!("No commit contains the pattern in its summary"))
+    } else {
+        let rev_aliases = commits
+            .iter()
+            .enumerate()
+            .map(|(i, commit)| {
+                let bname = if i > 0 {
+                    branches
+                        .get(&commit.id())
+                        .map(|n| format!("({}) ", n))
+                        .unwrap_or_else(String::new)
+                } else {
+                    String::new()
+                };
+                format!(
+                    "{} {}{}",
+                    &style(&commit.id().to_string()[0..10]).blue(),
+                    style(bname).green(),
+                    commit.summary().unwrap_or("no commit summary")
+                )
+            })
+            .collect::<Vec<_>>();
+        if upstream.is_none() {
+            println!("Select a commit to amend (no upstream for HEAD):");
+        } else {
+            println!("Select a commit to amend:");
+        }
+        let selected = Select::new().items(&rev_aliases).default(0).interact();
+        Ok(repo.find_commit(commits[selected?].id())?)
+    }
+}
+
+fn format_ref(rf: &git2::Reference<'_>) -> Result<String, anyhow::Error> {
+    let shorthand = rf.shorthand().unwrap_or("<unnamed>");
+    let sha = rf.peel_to_commit()?.id().to_string();
+    Ok(format!("{} ({})", shorthand, &sha[..10]))
+}
+
+fn print_diff(kind: Changes) -> Result<(), anyhow::Error> {
+    let mut args = vec!["diff", "--stat"];
+    if kind == Changes::Staged {
+        args.push("--cached");
+    }
+    let status = Command::new("git").args(&args).spawn()?.wait()?;
+    if status.success() {
+        Ok(())
+    } else {
+        bail!("git diff failed")
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -247,10 +247,6 @@ fn select_commit_to_amend<'a>(
         })
         .collect();
     if let Some(message_pattern) = message_pattern.as_ref() {
-        eprintln!(
-            "trying to find message_pattern in {} commits",
-            commits.len()
-        );
         commits
             .into_iter()
             .find(|commit| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,14 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
 use std::env;
-use std::process::Command;
 
-use anyhow::{anyhow, bail};
-use console::style;
-use dialoguer::{Confirm, Select};
-use git2::{Branch, Commit, Diff, Object, ObjectType, Oid, Rebase, Repository};
 use structopt::StructOpt;
 
 const UPSTREAM_VAR: &str = "GIT_INSTAFIX_UPSTREAM";
@@ -54,12 +48,9 @@ struct Args {
     /// Specify a commit to ammend by the subject line of the commit
     #[structopt(short = "P", long)]
     commit_message_pattern: Option<String>,
-}
 
-#[derive(Eq, PartialEq, Debug)]
-enum Changes {
-    Staged,
-    Unstaged,
+    #[structopt(long, env(UPSTREAM_VAR))]
+    default_upstream_branch: Option<String>,
 }
 
 fn main() {
@@ -67,333 +58,17 @@ fn main() {
     if env::args().next().unwrap().ends_with("squash") {
         args.squash = true
     }
-    if let Err(e) = run(args.squash, args.max_commits, args.commit_message_pattern) {
+    if let Err(e) = git_fixup::instafix(
+        args.squash,
+        args.max_commits,
+        args.commit_message_pattern,
+        args.default_upstream_branch.as_deref(),
+    ) {
         // An empty message means don't display any error message
         let msg = e.to_string();
         if !msg.is_empty() {
             println!("Error: {:#}", e);
         }
         std::process::exit(1);
-    }
-}
-
-fn run(
-    _squash: bool,
-    max_commits: usize,
-    message_pattern: Option<String>,
-) -> Result<(), anyhow::Error> {
-    let repo = Repository::open(".")?;
-    let diff = create_diff(&repo)?;
-    let head = repo
-        .head()
-        .map_err(|e| anyhow!("HEAD is not pointing at a valid branch: {}", e))?;
-    let head_branch = Branch::wrap(head);
-    println!("head_branch: {:?}", head_branch.name().unwrap().unwrap());
-    let upstream = get_upstream(&repo, &head_branch)?;
-    let commit_to_amend = select_commit_to_amend(&repo, upstream, max_commits, &message_pattern)?;
-    do_fixup_commit(&repo, &head_branch, &commit_to_amend, false)?;
-    println!("selected: {}", disp(&commit_to_amend));
-    let current_branch = Branch::wrap(repo.head()?);
-    do_rebase(&repo, &current_branch, &commit_to_amend, &diff)?;
-
-    Ok(())
-}
-
-fn do_rebase(
-    repo: &Repository,
-    branch: &Branch,
-    commit_to_amend: &Commit,
-    diff: &Diff,
-) -> Result<(), anyhow::Error> {
-    let first_parent = repo.find_annotated_commit(commit_parent(commit_to_amend)?.id())?;
-    let branch_commit = repo.reference_to_annotated_commit(branch.get())?;
-    let fixup_commit = branch.get().peel_to_commit()?;
-    let fixup_message = fixup_commit.message();
-
-    let rebase = &mut repo
-        .rebase(Some(&branch_commit), Some(&first_parent), None, None)
-        .map_err(|e| anyhow!("Error starting rebase: {}", e))?;
-    match do_rebase_inner(repo, rebase, diff, fixup_message) {
-        Ok(_) => {
-            rebase.finish(None)?;
-            Ok(())
-        }
-        Err(e) => {
-            eprintln!("Aborting rebase, please apply it manualy via");
-            eprintln!(
-                "    git rebase --interactive --autosquash {}~",
-                first_parent.id()
-            );
-            rebase.abort()?;
-            Err(e)
-        }
-    }
-}
-
-fn do_rebase_inner(
-    repo: &Repository,
-    rebase: &mut Rebase,
-    diff: &Diff,
-    fixup_message: Option<&str>,
-) -> Result<(), anyhow::Error> {
-    let sig = repo.signature()?;
-
-    let mut branches: HashMap<Oid, Branch> = HashMap::new();
-    for (branch, _type) in repo.branches(Some(git2::BranchType::Local))?.flatten() {
-        let oid = branch.get().peel_to_commit()?.id();
-        // TODO: handle multiple branches pointing to the same commit
-        branches.insert(oid, branch);
-    }
-
-    match rebase.next() {
-        Some(ref res) => {
-            let op = res.as_ref().map_err(|e| anyhow!("No commit: {}", e))?;
-            let target_commit = repo.find_commit(op.id())?;
-            repo.apply(diff, git2::ApplyLocation::Both, None)?;
-            let mut idx = repo.index()?;
-            let oid = idx.write_tree()?;
-            let tree = repo.find_tree(oid)?;
-
-            // TODO: Support squash amends
-
-            let rewrit_id = target_commit.amend(None, None, None, None, None, Some(&tree))?;
-            repo.reset(
-                &repo.find_object(rewrit_id, None)?,
-                git2::ResetType::Soft,
-                None,
-            )?;
-
-            rewrit_id
-        }
-        None => bail!("Unable to start rebase: no first step in rebase"),
-    };
-
-    while let Some(ref res) = rebase.next() {
-        use git2::RebaseOperationType::*;
-
-        let op = res.as_ref().map_err(|e| anyhow!("Err: {}", e))?;
-        match op.kind() {
-            Some(Pick) => {
-                let commit = repo.find_commit(op.id())?;
-                if commit.message() != fixup_message {
-                    let new_id = rebase.commit(None, &sig, None)?;
-                    if let Some(branch) = branches.get_mut(&commit.id()) {
-                        branch
-                            .get_mut()
-                            .set_target(new_id, "git-fixup retarget historical branch")?;
-                    }
-                }
-            }
-            Some(Fixup) | Some(Squash) | Some(Exec) | Some(Edit) | Some(Reword) => {
-                // None of this should happen, we'd need to manually create the commits
-                bail!("Unable to handle {:?} rebase operation", op.kind().unwrap())
-            }
-            None => {}
-        }
-    }
-
-    Ok(())
-}
-
-fn commit_parent<'a>(commit: &'a Commit) -> Result<Commit<'a>, anyhow::Error> {
-    match commit.parents().next() {
-        Some(c) => Ok(c),
-        None => bail!("Commit '{}' has no parents", disp(&commit)),
-    }
-}
-
-/// Display a commit as "short_hash summary"
-fn disp(commit: &Commit) -> String {
-    format!(
-        "{} {}",
-        &commit.id().to_string()[0..10],
-        commit.summary().unwrap_or("<no summary>"),
-    )
-}
-
-fn get_upstream<'a>(
-    repo: &'a Repository,
-    head_branch: &'a Branch,
-) -> Result<Option<Object<'a>>, anyhow::Error> {
-    let upstream = if let Ok(upstream_name) = env::var(UPSTREAM_VAR) {
-        let branch = repo
-            .branches(None)?
-            .filter_map(|branch| branch.ok().map(|(b, _type)| b))
-            .find(|b| {
-                b.name()
-                    .map(|n| n.expect("valid utf8 branchname") == &upstream_name)
-                    .unwrap_or(false)
-            })
-            .ok_or_else(|| anyhow!("cannot find branch with name {:?}", upstream_name))?;
-        branch.into_reference().peel(ObjectType::Commit)?
-    } else {
-        if let Ok(upstream) = head_branch.upstream() {
-            upstream.into_reference().peel(ObjectType::Commit)?
-        } else {
-            return Ok(None);
-        }
-    };
-
-    let mb = repo.merge_base(
-        head_branch
-            .get()
-            .target()
-            .expect("all branches should ahve a target"),
-        upstream.id(),
-    )?;
-    let commit = repo.find_object(mb, None).unwrap();
-
-    Ok(Some(commit))
-}
-
-/// Get a diff either from the index or the diff from the index to the working tree
-fn create_diff(repo: &Repository) -> Result<Diff, anyhow::Error> {
-    let head = repo.head()?;
-    let head_tree = head.peel_to_tree()?;
-    let staged_diff = repo.diff_tree_to_index(Some(&head_tree), None, None)?;
-    let diffstat = staged_diff.stats()?;
-    let diff = if diffstat.files_changed() == 0 {
-        let diff = repo.diff_index_to_workdir(None, None)?;
-        let dirty_workdir_stats = diff.stats()?;
-        if dirty_workdir_stats.files_changed() > 0 {
-            print_diff(Changes::Unstaged)?;
-            if !Confirm::new()
-                .with_prompt("Nothing staged, stage and commit everything?")
-                .interact()?
-            {
-                bail!("");
-            }
-        } else {
-            bail!("Nothing staged and no tracked files have any changes");
-        }
-        repo.apply(&diff, git2::ApplyLocation::Index, None)?;
-        diff
-    } else {
-        println!("Staged changes:");
-        print_diff(Changes::Staged)?;
-        staged_diff
-    };
-
-    Ok(diff)
-}
-
-/// Commit the current index as a fixup or squash commit
-fn do_fixup_commit<'a>(
-    repo: &'a Repository,
-    head_branch: &'a Branch,
-    commit_to_amend: &'a Commit,
-    squash: bool,
-) -> Result<(), anyhow::Error> {
-    let msg = if squash {
-        format!("squash! {}", commit_to_amend.id())
-    } else {
-        format!("fixup! {}", commit_to_amend.id())
-    };
-
-    let sig = repo.signature()?;
-    let mut idx = repo.index()?;
-    let tree = repo.find_tree(idx.write_tree()?)?;
-    let head_commit = head_branch.get().peel_to_commit()?;
-    repo.commit(Some("HEAD"), &sig, &sig, &msg, &tree, &[&head_commit])?;
-    Ok(())
-}
-
-fn select_commit_to_amend<'a>(
-    repo: &'a Repository,
-    upstream: Option<Object<'a>>,
-    max_commits: usize,
-    message_pattern: &Option<String>,
-) -> Result<Commit<'a>, anyhow::Error> {
-    let mut walker = repo.revwalk()?;
-    walker.push_head()?;
-    let commits = if let Some(upstream) = upstream.as_ref() {
-        let upstream_oid = upstream.id();
-        walker
-            .flat_map(|r| r)
-            .take_while(|rev| *rev != upstream_oid)
-            .take(max_commits)
-            .map(|rev| repo.find_commit(rev))
-            .collect::<Result<Vec<_>, _>>()?
-    } else {
-        walker
-            .flat_map(|r| r)
-            .take(max_commits)
-            .map(|rev| repo.find_commit(rev))
-            .collect::<Result<Vec<_>, _>>()?
-    };
-    if commits.len() == 0 {
-        bail!(
-            "No commits between {} and {:?}",
-            format_ref(&repo.head()?)?,
-            upstream.map(|u| u.id()).unwrap()
-        );
-    }
-    let branches: HashMap<Oid, String> = repo
-        .branches(None)?
-        .filter_map(|b| {
-            b.ok().and_then(|(b, _type)| {
-                let name: Option<String> = b.name().ok().and_then(|n| n.map(|n| n.to_owned()));
-                let oid = b.into_reference().resolve().ok().and_then(|r| r.target());
-                name.and_then(|name| oid.map(|oid| (oid, name)))
-            })
-        })
-        .collect();
-    if let Some(message_pattern) = message_pattern.as_ref() {
-        commits
-            .into_iter()
-            .find(|commit| {
-                commit
-                    .summary()
-                    .map(|s| s.contains(message_pattern))
-                    .unwrap_or(false)
-            })
-            .ok_or_else(|| anyhow::anyhow!("No commit contains the pattern in its summary"))
-    } else {
-        let rev_aliases = commits
-            .iter()
-            .enumerate()
-            .map(|(i, commit)| {
-                let bname = if i > 0 {
-                    branches
-                        .get(&commit.id())
-                        .map(|n| format!("({}) ", n))
-                        .unwrap_or_else(String::new)
-                } else {
-                    String::new()
-                };
-                format!(
-                    "{} {}{}",
-                    &style(&commit.id().to_string()[0..10]).blue(),
-                    style(bname).green(),
-                    commit.summary().unwrap_or("no commit summary")
-                )
-            })
-            .collect::<Vec<_>>();
-        if upstream.is_none() {
-            println!("Select a commit to amend (no upstream for HEAD):");
-        } else {
-            println!("Select a commit to amend:");
-        }
-        let selected = Select::new().items(&rev_aliases).default(0).interact();
-        Ok(repo.find_commit(commits[selected?].id())?)
-    }
-}
-
-fn format_ref(rf: &git2::Reference<'_>) -> Result<String, anyhow::Error> {
-    let shorthand = rf.shorthand().unwrap_or("<unnamed>");
-    let sha = rf.peel_to_commit()?.id().to_string();
-    Ok(format!("{} ({})", shorthand, &sha[..10]))
-}
-
-fn print_diff(kind: Changes) -> Result<(), anyhow::Error> {
-    let mut args = vec!["diff", "--stat"];
-    if kind == Changes::Staged {
-        args.push("--cached");
-    }
-    let status = Command::new("git").args(&args).spawn()?.wait()?;
-    if status.success() {
-        Ok(())
-    } else {
-        bail!("git diff failed")
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,13 +14,12 @@
 
 use std::collections::HashMap;
 use std::env;
-use std::error::Error;
 use std::process::Command;
 
-use anyhow::bail;
+use anyhow::{anyhow, bail};
 use console::style;
 use dialoguer::{Confirm, Select};
-use git2::{Branch, Commit, Diff, Object, ObjectType, Oid, Repository};
+use git2::{Branch, Commit, Diff, Object, ObjectType, Oid, Rebase, Repository};
 use structopt::StructOpt;
 
 const UPSTREAM_VAR: &str = "GIT_INSTAFIX_UPSTREAM";
@@ -72,53 +71,138 @@ fn main() {
         // An empty message means don't display any error message
         let msg = e.to_string();
         if !msg.is_empty() {
-            println!("Error: {}", e);
+            println!("Error: {:#}", e);
         }
         std::process::exit(1);
     }
 }
 
 fn run(
-    squash: bool,
+    _squash: bool,
     max_commits: usize,
     message_pattern: Option<String>,
-) -> Result<(), Box<dyn Error>> {
+) -> Result<(), anyhow::Error> {
     let repo = Repository::open(".")?;
+    let diff = create_diff(&repo)?;
     let head = repo
         .head()
-        .map_err(|e| format!("HEAD is not pointing at a valid branch: {}", e))?;
-    let head_tree = head.peel_to_tree()?;
+        .map_err(|e| anyhow!("HEAD is not pointing at a valid branch: {}", e))?;
     let head_branch = Branch::wrap(head);
-    let diff = repo.diff_tree_to_index(Some(&head_tree), None, None)?;
+    println!("head_branch: {:?}", head_branch.name().unwrap().unwrap());
     let upstream = get_upstream(&repo, &head_branch)?;
-    let commit_to_amend = create_fixup_commit(
-        &repo,
-        &head_branch,
-        upstream,
-        &diff,
-        squash,
-        max_commits,
-        &message_pattern,
-    )?;
-    println!(
-        "selected: {} {}",
-        &commit_to_amend.id().to_string()[0..10],
-        commit_to_amend.summary().unwrap_or("")
-    );
-    // do the rebase
-    let target_id = format!("{}~", commit_to_amend.id());
-    Command::new("git")
-        .args(&["rebase", "--interactive", "--autosquash", &target_id])
-        .env("GIT_SEQUENCE_EDITOR", "true")
-        .spawn()?
-        .wait()?;
+    let commit_to_amend = select_commit_to_amend(&repo, upstream, max_commits, &message_pattern)?;
+    do_fixup_commit(&repo, &head_branch, &commit_to_amend, false)?;
+    println!("selected: {}", disp(&commit_to_amend));
+    let current_branch = Branch::wrap(repo.head()?);
+    do_rebase(&repo, &current_branch, &commit_to_amend, &diff)?;
+
     Ok(())
+}
+
+fn do_rebase(
+    repo: &Repository,
+    branch: &Branch,
+    commit_to_amend: &Commit,
+    diff: &Diff,
+) -> Result<(), anyhow::Error> {
+    let first_parent = repo.find_annotated_commit(commit_parent(commit_to_amend)?.id())?;
+    let branch_commit = repo.reference_to_annotated_commit(branch.get())?;
+    let fixup_commit = branch.get().peel_to_commit()?;
+    let fixup_message = fixup_commit.message();
+
+    let rebase = &mut repo
+        .rebase(Some(&branch_commit), Some(&first_parent), None, None)
+        .map_err(|e| anyhow!("Error starting rebase: {}", e))?;
+    match do_rebase_inner(repo, rebase, diff, fixup_message) {
+        Ok(_) => {
+            rebase.finish(None)?;
+            Ok(())
+        }
+        Err(e) => {
+            eprintln!("Aborting rebase, please apply it manualy via");
+            eprintln!(
+                "    git rebase --interactive --autosquash {}~",
+                first_parent.id()
+            );
+            rebase.abort()?;
+            Err(e)
+        }
+    }
+}
+
+fn do_rebase_inner(
+    repo: &Repository,
+    rebase: &mut Rebase,
+    diff: &Diff,
+    fixup_message: Option<&str>,
+) -> Result<(), anyhow::Error> {
+    let sig = repo.signature()?;
+
+    match rebase.next() {
+        Some(ref res) => {
+            let op = res.as_ref().map_err(|e| anyhow!("No commit: {}", e))?;
+            let target_commit = repo.find_commit(op.id())?;
+            repo.apply(diff, git2::ApplyLocation::Both, None)?;
+            let mut idx = repo.index()?;
+            let oid = idx.write_tree()?;
+            let tree = repo.find_tree(oid)?;
+
+            // TODO: Support squash amends
+
+            let rewrit_id = target_commit.amend(None, None, None, None, None, Some(&tree))?;
+            repo.reset(
+                &repo.find_object(rewrit_id, None)?,
+                git2::ResetType::Soft,
+                None,
+            )?;
+
+            rewrit_id
+        }
+        None => bail!("Unable to start rebase: no first step in rebase"),
+    };
+
+    while let Some(ref res) = rebase.next() {
+        use git2::RebaseOperationType::*;
+
+        let op = res.as_ref().map_err(|e| anyhow!("Err: {}", e))?;
+        match op.kind() {
+            Some(Pick) => {
+                let commit = repo.find_commit(op.id())?;
+                if commit.message() != fixup_message {
+                    rebase.commit(None, &sig, None)?;
+                }
+            }
+            Some(Fixup) | Some(Squash) | Some(Exec) | Some(Edit) | Some(Reword) => {
+                // None of this should happen, we'd need to manually create the commits
+                bail!("Unable to handle {:?} rebase operation", op.kind().unwrap())
+            }
+            None => {}
+        }
+    }
+
+    Ok(())
+}
+
+fn commit_parent<'a>(commit: &'a Commit) -> Result<Commit<'a>, anyhow::Error> {
+    match commit.parents().next() {
+        Some(c) => Ok(c),
+        None => bail!("Commit '{}' has no parents", disp(&commit)),
+    }
+}
+
+/// Display a commit as "short_hash summary"
+fn disp(commit: &Commit) -> String {
+    format!(
+        "{} {}",
+        &commit.id().to_string()[0..10],
+        commit.summary().unwrap_or("<no summary>"),
+    )
 }
 
 fn get_upstream<'a>(
     repo: &'a Repository,
     head_branch: &'a Branch,
-) -> Result<Option<Object<'a>>, Box<dyn Error>> {
+) -> Result<Option<Object<'a>>, anyhow::Error> {
     let upstream = if let Ok(upstream_name) = env::var(UPSTREAM_VAR) {
         let branch = repo
             .branches(None)?
@@ -128,7 +212,7 @@ fn get_upstream<'a>(
                     .map(|n| n.expect("valid utf8 branchname") == &upstream_name)
                     .unwrap_or(false)
             })
-            .ok_or_else(|| format!("cannot find branch with name {:?}", upstream_name))?;
+            .ok_or_else(|| anyhow!("cannot find branch with name {:?}", upstream_name))?;
         branch.into_reference().peel(ObjectType::Commit)?
     } else {
         if let Ok(upstream) = head_branch.upstream() {
@@ -150,48 +234,44 @@ fn get_upstream<'a>(
     Ok(Some(commit))
 }
 
-fn create_fixup_commit<'a>(
-    repo: &'a Repository,
-    head_branch: &'a Branch,
-    upstream: Option<Object<'a>>,
-    diff: &'a Diff,
-    squash: bool,
-    max_commits: usize,
-    message_pattern: &Option<String>,
-) -> Result<Commit<'a>, Box<dyn Error>> {
-    let diffstat = diff.stats()?;
-    if diffstat.files_changed() == 0 {
-        let dirty_workdir_stats = repo.diff_index_to_workdir(None, None)?.stats()?;
+/// Get a diff either from the index or the diff from the index to the working tree
+fn create_diff(repo: &Repository) -> Result<Diff, anyhow::Error> {
+    let head = repo.head()?;
+    let head_tree = head.peel_to_tree()?;
+    let staged_diff = repo.diff_tree_to_index(Some(&head_tree), None, None)?;
+    let diffstat = staged_diff.stats()?;
+    let diff = if diffstat.files_changed() == 0 {
+        let diff = repo.diff_index_to_workdir(None, None)?;
+        let dirty_workdir_stats = diff.stats()?;
         if dirty_workdir_stats.files_changed() > 0 {
             print_diff(Changes::Unstaged)?;
             if !Confirm::new()
                 .with_prompt("Nothing staged, stage and commit everything?")
                 .interact()?
             {
-                return Err("".into());
+                bail!("");
             }
         } else {
-            return Err("Nothing staged and no tracked files have any changes".into());
+            bail!("Nothing staged and no tracked files have any changes");
         }
-        let pathspecs: Vec<&str> = vec![];
-        let mut idx = repo.index()?;
-        idx.update_all(&pathspecs, None)?;
-        idx.write()?;
+        repo.apply(&diff, git2::ApplyLocation::Index, None)?;
+        diff
     } else {
         println!("Staged changes:");
         print_diff(Changes::Staged)?;
-    }
-    let commit_to_amend = select_commit_to_amend(&repo, upstream, max_commits, message_pattern)?;
-    do_fixup_commit(&repo, &head_branch, &commit_to_amend, squash)?;
-    Ok(commit_to_amend)
+        staged_diff
+    };
+
+    Ok(diff)
 }
 
+/// Commit the current index as a fixup or squash commit
 fn do_fixup_commit<'a>(
     repo: &'a Repository,
     head_branch: &'a Branch,
     commit_to_amend: &'a Commit,
     squash: bool,
-) -> Result<(), Box<dyn Error>> {
+) -> Result<(), anyhow::Error> {
     let msg = if squash {
         format!("squash! {}", commit_to_amend.id())
     } else {
@@ -278,9 +358,9 @@ fn select_commit_to_amend<'a>(
             })
             .collect::<Vec<_>>();
         if upstream.is_none() {
-            eprintln!("Select a commit to amend (no upstream for HEAD):");
+            println!("Select a commit to amend (no upstream for HEAD):");
         } else {
-            eprintln!("Select a commit to amend:");
+            println!("Select a commit to amend:");
         }
         let selected = Select::new().items(&rev_aliases).default(0).interact();
         Ok(repo.find_commit(commits[selected?].id())?)
@@ -293,7 +373,7 @@ fn format_ref(rf: &git2::Reference<'_>) -> Result<String, anyhow::Error> {
     Ok(format!("{} ({})", shorthand, &sha[..10]))
 }
 
-fn print_diff(kind: Changes) -> Result<(), Box<dyn Error>> {
+fn print_diff(kind: Changes) -> Result<(), anyhow::Error> {
     let mut args = vec!["diff", "--stat"];
     if kind == Changes::Staged {
         args.push("--cached");
@@ -302,6 +382,6 @@ fn print_diff(kind: Changes) -> Result<(), Box<dyn Error>> {
     if status.success() {
         Ok(())
     } else {
-        Err("git diff failed".into())
+        bail!("git diff failed")
     }
 }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -211,6 +211,63 @@ new
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// rebase-with-intermediates tests
+
+#[test]
+fn test_rebase_with_intermediates() {
+    let td = assert_fs::TempDir::new().unwrap();
+    git_init(&td);
+
+    git_commits(&["a", "b", "c"], &td);
+    git(&["checkout", "-b", "int_1", ":/b"], &td);
+    git_commits(&["d", "e"], &td);
+    git(&["checkout", "-b", "int_2"], &td);
+
+    git_commits(&["f", "g"], &td);
+
+    git(&["checkout", "-b", "changes"], &td);
+
+    git_commits(&["h", "i"], &td);
+
+    let out = git_log(&td);
+    let expected = "\
+* i HEAD -> changes
+* h
+* g int_2
+* f
+* e int_1
+* d
+| * c main
+|/
+* b
+* a
+";
+    assert_eq!(
+        out, expected,
+        "pre rebase\nactual:\n{}\nexpected:\n{}",
+        out, expected
+    );
+
+    if let Err(e) = rebase("main", &td).ok() {
+        panic!("ERROR: {}", e);
+    }
+
+    let out = git_log(&td);
+    let expected = "\
+* i HEAD -> changes
+* h
+* g int_2
+* f
+* e int_1
+* d
+* c main
+* b
+* a
+";
+    assert_eq!(out, expected, "\nactual:\n{}\nexpected:\n{}", out, expected);
+}
+
+///////////////////////////////////////////////////////////////////////////////
 // Helpers
 
 fn git_commits(ids: &[&str], tempdir: &assert_fs::TempDir) {
@@ -285,5 +342,12 @@ fn git_inner(args: &[&str], tempdir: &assert_fs::TempDir) -> Command {
 fn fixup(dir: &assert_fs::TempDir) -> Command {
     let mut c = Command::cargo_bin("git-fixup").unwrap();
     c.current_dir(&dir.path());
+    c
+}
+
+fn rebase(onto: &str, dir: &assert_fs::TempDir) -> Command {
+    let mut c = Command::cargo_bin("git-rebase-with-intermediates").unwrap();
+    c.current_dir(&dir.path());
+    c.arg(onto);
     c
 }


### PR DESCRIPTION
With this, it's straightforward to have a bunch of intermediate branches, a
future script will allow `git push-all-intermediates` that will make working
with github with multiple PRs that depend on each other more ergonomic.

See the new test for exactly what this does.